### PR TITLE
chore: remove tidb client

### DIFF
--- a/db/client.ts
+++ b/db/client.ts
@@ -1,7 +1,5 @@
 import 'dotenv/config';
-import { connect as tidbConnect } from '@tidbcloud/serverless';
 import { drizzle as mysql } from 'drizzle-orm/mysql2';
-import { drizzle as tidb } from 'drizzle-orm/tidb-serverless';
 import { createConnection as mysqlConnect } from 'mysql2/promise';
 import * as authScehma from './schema/auth';
 import * as sbSchema from './schema/superbetter';
@@ -9,20 +7,12 @@ import * as sbSchema from './schema/superbetter';
 const schema = { ...authScehma, ...sbSchema };
 
 const createDrizzle = async () => {
-  if (process.env.DB_TYPE?.toLowerCase() === 'tidb') {
-    const client = tidbConnect({
-      host: process.env.DB_HOST,
-      username: process.env.DB_USERNAME,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_DATABASE,
-    });
-    return tidb({ client, schema });
-  }
   const client = await mysqlConnect({
     host: process.env.DB_HOST,
     user: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
+    ssl: process.env.DB_TYPE?.toLowerCase() === 'tidb' ? {} : undefined,
   });
   return mysql(client, { schema, mode: 'default' });
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "1.7.4",
-    "@tidbcloud/serverless": "0.2.0",
     "dotenv": "16.4.7",
     "drizzle-orm": "0.38.4",
     "mysql2": "3.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@auth/drizzle-adapter':
         specifier: 1.7.4
         version: 1.7.4
-      '@tidbcloud/serverless':
-        specifier: 0.2.0
-        version: 0.2.0
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
@@ -6399,7 +6396,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tidbcloud/serverless@0.2.0': {}
+  '@tidbcloud/serverless@0.2.0':
+    optional: true
 
   '@trysound/sax@0.2.0': {}
 


### PR DESCRIPTION
select({id: hoge.id}) の表現が型エラーでできなかった原因は tidb の client にありそうだった 詳細はわからないが mysqlConnectionで接続できそうだったのでそちらに1本化する