### PR TITLE
feat: ミッション詳細画面でsubmitボタンの連打を無効化

### DIFF
--- a/src/app/(private)/missions/[missionId]/_actions/get-all-entities.ts
+++ b/src/app/(private)/missions/[missionId]/_actions/get-all-entities.ts
@@ -1,0 +1,29 @@
+import 'server-only';
+
+import { getPowerups } from '@/app/(private)/_actions/get-powerup';
+import { getQuests } from '@/app/(private)/_actions/get-quest';
+import { getVillains } from '@/app/(private)/_actions/get-villain';
+
+export type AllEntities = Awaited<ReturnType<typeof getAllEntities>>;
+
+export const getAllEntities = async () => {
+  const LIMIT = 5;
+  const powerups = await getPowerups({ limit: LIMIT });
+  const quests = await getQuests({ limit: LIMIT });
+  const villains = await getVillains({ limit: LIMIT });
+  if (powerups.type === 'error') {
+    throw new Error(powerups.error.message);
+  }
+  if (quests.type === 'error') {
+    throw new Error(quests.error.message);
+  }
+  if (villains.type === 'error') {
+    throw new Error(villains.error.message);
+  }
+  return {
+    LIMIT,
+    powerups: powerups.data,
+    quests: quests.data,
+    villains: villains.data,
+  };
+};

--- a/src/app/(private)/missions/[missionId]/_actions/post-entity-history.tsx
+++ b/src/app/(private)/missions/[missionId]/_actions/post-entity-history.tsx
@@ -1,0 +1,21 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { postPowerupHistory } from '@/app/(private)/_actions/post-powerup-history';
+import { postQuestHistory } from '@/app/(private)/_actions/post-quest-history';
+import { postVillainHistory } from '@/app/(private)/_actions/post-villain-history';
+import type { EntityType } from '@/db/types/mission';
+
+export const postEntityHistory = async (entity: {
+  type: EntityType;
+  id: string;
+}) => {
+  if (entity.type === 'powerup') {
+    await postPowerupHistory(entity.id);
+  } else if (entity.type === 'quest') {
+    await postQuestHistory(entity.id);
+  } else if (entity.type === 'villain') {
+    await postVillainHistory(entity.id);
+  }
+  revalidatePath('/missions/[missionId]', 'page');
+};

--- a/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
+++ b/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import { type ReactNode, useTransition } from 'react';
 import { Android, ScriptText, Zap } from '@/assets/icons';
 import { Button } from '@/components/button';
 import { Radio } from '@/components/radio';
@@ -13,6 +13,7 @@ import { getEntity, getEntityValue } from '../../_utils/converter';
 
 export const MissionForm = ({ entities }: { entities: AllEntities }) => {
   const { powerups, quests, villains, LIMIT } = entities;
+  const [isPending, startTransition] = useTransition();
   return (
     <form
       action={async (a) => {
@@ -21,7 +22,9 @@ export const MissionForm = ({ entities }: { entities: AllEntities }) => {
           return;
         }
         const entity = getEntity(val);
-        await postEntityHistory(entity);
+        startTransition(async () => {
+          await postEntityHistory(entity);
+        });
       }}
     >
       <div
@@ -65,7 +68,9 @@ export const MissionForm = ({ entities }: { entities: AllEntities }) => {
             py: '8px',
           })}
         >
-          <Button type="submit">つかった / いどんだ / たたかった</Button>
+          <Button disabled={isPending} type="submit">
+            つかった / いどんだ / たたかった
+          </Button>
         </div>
       </div>
     </form>

--- a/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
+++ b/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { Android, ScriptText, Zap } from '@/assets/icons';
+import { Button } from '@/components/button';
+import { Radio } from '@/components/radio';
+import type { EntityType } from '@/db/types/mission';
+import { css } from '@/styled-system/css';
+import type { AllEntities } from '../../_actions/get-all-entities';
+import { postEntityHistory } from '../../_actions/post-entity-history';
+import { getEntity, getEntityValue } from '../../_utils/converter';
+
+export const MissionForm = ({ entities }: { entities: AllEntities }) => {
+  const { powerups, quests, villains, LIMIT } = entities;
+  return (
+    <form
+      action={async (a) => {
+        const val = a.get('entity') as string | null;
+        if (!val) {
+          return;
+        }
+        const entity = getEntity(val);
+        await postEntityHistory(entity);
+      }}
+    >
+      <div
+        className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        })}
+      >
+        <div
+          className={css({
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+          })}
+        >
+          <EntityList
+            type="powerup"
+            entities={powerups.records}
+            showMore={powerups.count > LIMIT}
+            showMoreLink="/powerups"
+          />
+          <EntityList
+            type="quest"
+            entities={quests.records}
+            showMore={quests.count > LIMIT}
+            showMoreLink="/quests"
+          />
+          <EntityList
+            type="villain"
+            entities={villains.records}
+            showMore={villains.count > LIMIT}
+            showMoreLink="/villains"
+          />
+        </div>
+        <div
+          className={css({
+            backgroundColor: 'background',
+            display: 'flex',
+            justifyContent: 'center',
+            py: '8px',
+          })}
+        >
+          <Button type="submit">つかった / いどんだ / たたかった</Button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+const EntityList = ({
+  type,
+  entities,
+  showMore,
+  showMoreLink,
+}: {
+  type: EntityType;
+  entities: { id: string; title: string }[];
+  showMore: boolean;
+  showMoreLink: string;
+}) => {
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+        px: '8px',
+      })}
+    >
+      <div
+        className={css({
+          display: 'flex',
+          justifyContent: 'space-between',
+        })}
+      >
+        <div
+          className={css({
+            alignItems: 'center',
+            display: 'flex',
+            gap: '8px',
+          })}
+        >
+          {Icon[type]}
+          <p
+            className={css({
+              textStyle: 'Body.secondary',
+            })}
+          >
+            {Label[type]}
+          </p>
+        </div>
+      </div>
+      <div
+        className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+        })}
+      >
+        {entities.map((p) => (
+          <Radio
+            required
+            key={p.id}
+            name="entity"
+            value={getEntityValue({ type, id: p.id })}
+            label={p.title}
+          />
+        ))}
+      </div>
+      {showMore && (
+        <div className={css({ textAlign: 'center' })}>
+          <Link
+            href={showMoreLink}
+            className={css({ padding: '12px', textStyle: 'Body.secondary' })}
+          >
+            もっとみる
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Icon = {
+  powerup: <Zap className={css({ width: '[20px]' })} />,
+  quest: <ScriptText className={css({ width: '[20px]' })} />,
+  villain: <Android className={css({ width: '[20px]' })} />,
+  epicwin: <>未定</>,
+} as const satisfies Record<EntityType, ReactNode>;
+
+const Label = {
+  powerup: 'パワーアップ',
+  quest: 'クエスト',
+  villain: 'ヴィラン',
+  epicwin: '未定',
+} as const satisfies Record<EntityType, string>;

--- a/src/app/(private)/missions/[missionId]/page.tsx
+++ b/src/app/(private)/missions/[missionId]/page.tsx
@@ -1,21 +1,9 @@
-import { revalidatePath } from 'next/cache';
-import Link from 'next/link';
-import type { ReactNode } from 'react';
 import { getMission } from '@/app/(private)/_actions/get-mission';
-import { getPowerups } from '@/app/(private)/_actions/get-powerup';
-import { getQuests } from '@/app/(private)/_actions/get-quest';
-import { getVillains } from '@/app/(private)/_actions/get-villain';
-import { postPowerupHistory } from '@/app/(private)/_actions/post-powerup-history';
-import { postQuestHistory } from '@/app/(private)/_actions/post-quest-history';
-import { postVillainHistory } from '@/app/(private)/_actions/post-villain-history';
 import { MissionEntities } from '@/app/(private)/_components/mission/entitity';
-import { Android, ScriptText, Zap } from '@/assets/icons';
-import { Button } from '@/components/button';
-import { Radio } from '@/components/radio';
-import type { EntityType } from '@/db/types/mission';
 import { css } from '@/styled-system/css';
 import { Header } from '../../_components/header';
-import { getEntity, getEntityValue } from './_utils/converter';
+import { getAllEntities } from './_actions/get-all-entities';
+import { MissionForm } from './_components/mission-form';
 
 const Page = async (props: { params: Promise<{ missionId: string }> }) => {
   const { missionId } = await props.params;
@@ -23,6 +11,7 @@ const Page = async (props: { params: Promise<{ missionId: string }> }) => {
   if (mission.type === 'error') {
     throw new Error(mission.error.message);
   }
+  const entities = await getAllEntities();
   return (
     <main
       className={css({
@@ -85,180 +74,10 @@ const Page = async (props: { params: Promise<{ missionId: string }> }) => {
             />
           </div>
         </div>
-        <Form />
+        <MissionForm entities={entities} />
       </div>
     </main>
   );
 };
 
 export default Page;
-
-const Form = async () => {
-  const LIMIT = 5;
-  const powerups = await getPowerups({ limit: LIMIT });
-  const quests = await getQuests({ limit: LIMIT });
-  const villains = await getVillains({ limit: LIMIT });
-  if (powerups.type === 'error') {
-    throw new Error(powerups.error.message);
-  }
-  if (quests.type === 'error') {
-    throw new Error(quests.error.message);
-  }
-  if (villains.type === 'error') {
-    throw new Error(villains.error.message);
-  }
-
-  return (
-    <form
-      action={async (a) => {
-        'use server';
-        const val = a.get('entity') as string | null;
-        if (!val) {
-          return;
-        }
-        const entity = getEntity(val);
-        if (entity.type === 'powerup') {
-          await postPowerupHistory(entity.id);
-        } else if (entity.type === 'quest') {
-          await postQuestHistory(entity.id);
-        } else if (entity.type === 'villain') {
-          await postVillainHistory(entity.id);
-        }
-        revalidatePath('/missions/[missionId]', 'page');
-      }}
-    >
-      <div
-        className={css({
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '16px',
-        })}
-      >
-        <div
-          className={css({
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '16px',
-          })}
-        >
-          <EntityList
-            type="powerup"
-            entities={powerups.data.records}
-            showMore={powerups.data.count > LIMIT}
-            showMoreLink="/powerups"
-          />
-          <EntityList
-            type="quest"
-            entities={quests.data.records}
-            showMore={quests.data.count > LIMIT}
-            showMoreLink="/quests"
-          />
-          <EntityList
-            type="villain"
-            entities={villains.data.records}
-            showMore={villains.data.count > LIMIT}
-            showMoreLink="/villains"
-          />
-        </div>
-        <div
-          className={css({
-            backgroundColor: 'background',
-            display: 'flex',
-            justifyContent: 'center',
-            py: '8px',
-          })}
-        >
-          <Button type="submit">つかった / いどんだ / たたかった</Button>
-        </div>
-      </div>
-    </form>
-  );
-};
-
-const EntityList = ({
-  type,
-  entities,
-  showMore,
-  showMoreLink,
-}: {
-  type: EntityType;
-  entities: { id: string; title: string }[];
-  showMore: boolean;
-  showMoreLink: string;
-}) => {
-  return (
-    <div
-      className={css({
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '4px',
-        px: '8px',
-      })}
-    >
-      <div
-        className={css({
-          display: 'flex',
-          justifyContent: 'space-between',
-        })}
-      >
-        <div
-          className={css({
-            alignItems: 'center',
-            display: 'flex',
-            gap: '8px',
-          })}
-        >
-          {Icon[type]}
-          <p
-            className={css({
-              textStyle: 'Body.secondary',
-            })}
-          >
-            {Label[type]}
-          </p>
-        </div>
-      </div>
-      <div
-        className={css({
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-        })}
-      >
-        {entities.map((p) => (
-          <Radio
-            required
-            key={p.id}
-            name="entity"
-            value={getEntityValue({ type, id: p.id })}
-            label={p.title}
-          />
-        ))}
-      </div>
-      {showMore && (
-        <div className={css({ textAlign: 'center' })}>
-          <Link
-            href={showMoreLink}
-            className={css({ padding: '12px', textStyle: 'Body.secondary' })}
-          >
-            もっとみる
-          </Link>
-        </div>
-      )}
-    </div>
-  );
-};
-
-const Icon = {
-  powerup: <Zap className={css({ width: '[20px]' })} />,
-  quest: <ScriptText className={css({ width: '[20px]' })} />,
-  villain: <Android className={css({ width: '[20px]' })} />,
-  epicwin: <>未定</>,
-} as const satisfies Record<EntityType, ReactNode>;
-
-const Label = {
-  powerup: 'パワーアップ',
-  quest: 'クエスト',
-  villain: 'ヴィラン',
-  epicwin: '未定',
-} as const satisfies Record<EntityType, string>;


### PR DESCRIPTION
## Summary
- MissionFormコンポーネントをクライアントサイド専用として切り出し
- useTransitionフックを使用してsubmitボタンの連打を防止
- server actionの実行中はボタンをdisabled状態にすることでUX改善

## 変更内容
- `src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx` - 新規作成したクライアントコンポーネント
- `src/app/(private)/missions/[missionId]/_actions/get-all-entities.ts` - エンティティ取得ロジックの抽出
- `src/app/(private)/missions/[missionId]/_actions/post-entity-history.tsx` - エンティティ履歴投稿の汎用化
- `src/app/(private)/missions/[missionId]/page.tsx` - フォームコンポーネントの分離

## Test plan
- [ ] ミッション詳細画面でフォーム送信が正常に動作することを確認
- [ ] submitボタン連打時にdisabled状態になることを確認
- [ ] 送信完了後にボタンが再度有効になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)