### PR TITLE
feat: MissionFormのレイアウト改善

### DIFF
--- a/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
+++ b/src/app/(private)/missions/[missionId]/_components/mission-form/index.tsx
@@ -26,52 +26,57 @@ export const MissionForm = ({ entities }: { entities: AllEntities }) => {
           await postEntityHistory(entity);
         });
       }}
+      className={css({
+        display: 'flex',
+        flexDirection: 'column',
+        height: '[100%]',
+      })}
     >
       <div
         className={css({
+          flex: '1',
+          minHeight: '[0]',
+          overflowY: 'auto',
           display: 'flex',
           flexDirection: 'column',
           gap: '16px',
+          padding: '16px',
         })}
       >
-        <div
-          className={css({
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '16px',
-          })}
-        >
-          <EntityList
-            type="powerup"
-            entities={powerups.records}
-            showMore={powerups.count > LIMIT}
-            showMoreLink="/powerups"
-          />
-          <EntityList
-            type="quest"
-            entities={quests.records}
-            showMore={quests.count > LIMIT}
-            showMoreLink="/quests"
-          />
-          <EntityList
-            type="villain"
-            entities={villains.records}
-            showMore={villains.count > LIMIT}
-            showMoreLink="/villains"
-          />
-        </div>
-        <div
-          className={css({
-            backgroundColor: 'background',
-            display: 'flex',
-            justifyContent: 'center',
-            py: '8px',
-          })}
-        >
-          <Button disabled={isPending} type="submit">
-            {isPending ? '送信中...' : 'つかった / いどんだ / たたかった'}
-          </Button>
-        </div>
+        <EntityList
+          type="powerup"
+          entities={powerups.records}
+          showMore={powerups.count > LIMIT}
+          showMoreLink="/powerups"
+        />
+        <EntityList
+          type="quest"
+          entities={quests.records}
+          showMore={quests.count > LIMIT}
+          showMoreLink="/quests"
+        />
+        <EntityList
+          type="villain"
+          entities={villains.records}
+          showMore={villains.count > LIMIT}
+          showMoreLink="/villains"
+        />
+      </div>
+      <div
+        className={css({
+          position: 'sticky',
+          bottom: 0,
+          backgroundColor: 'background',
+          display: 'flex',
+          justifyContent: 'center',
+          padding: '16px',
+          borderTop: '1px solid',
+          borderColor: 'interactive.border',
+        })}
+      >
+        <Button disabled={isPending} type="submit">
+          {isPending ? '送信中...' : 'つかった / いどんだ / たたかった'}
+        </Button>
       </div>
     </form>
   );

--- a/src/app/(private)/missions/[missionId]/page.tsx
+++ b/src/app/(private)/missions/[missionId]/page.tsx
@@ -74,7 +74,14 @@ const Page = async (props: { params: Promise<{ missionId: string }> }) => {
             />
           </div>
         </div>
-        <MissionForm entities={entities} />
+        <div
+          className={css({
+            flex: '1',
+            minHeight: '[0]',
+          })}
+        >
+          <MissionForm entities={entities} />
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- EntityListエリアをスクロール可能にし、submitボタンを固定位置に配置
- ユーザーがラジオボタンを選択した後にスクロールせずにsubmitできるUIに改善
- flexboxレイアウトを活用して利用可能な領域を最大限活用

## 変更内容
- MissionFormのレイアウトをflexboxで再構成
- EntityListエリアに `overflow-y: auto` を適用してスクロール可能に
- submitボタンを `position: sticky` で下部に固定
- 親コンテナで `flex: 1` を使用して利用可能な領域を最大限活用

## Test plan
- [ ] EntityListの各エンティティタイプ（powerup, quest, villain）のスクロール動作確認
- [ ] submitボタンの固定位置表示確認
- [ ] ラジオボタン選択・送信機能の動作確認
- [ ] モバイル・タブレット・デスクトップでのレスポンシブ表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)