### PR TITLE
feat: claude-code-reviewでsticky commentを有効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices


### PR DESCRIPTION
## Summary
- Claude Code Actionに`use_sticky_comment: true`オプションを追加
- レビューコメントが新しいPRコメントとして毎回投稿されるのではなく、既存のコメントを更新する形式に変更
- PRの履歴が整理され、レビューの進捗が追いやすくなる

## Test plan
- [ ] PRを作成して、Claude Code Reviewが動作することを確認
- [ ] 複数回レビューが実行された際に、コメントが更新されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)