### PR TITLE
feat: CalendarChartコンポーネントを追加

### DIFF
--- a/src/components/calendar-chart/index.stories.tsx
+++ b/src/components/calendar-chart/index.stories.tsx
@@ -154,3 +154,37 @@ export const WeekendLayoutTest = {
     },
   },
 } satisfies Story;
+
+export const MondayStartCalendar = {
+  args: {
+    month: new Date(2024, 8, 1), // 2024年9月（日曜日スタート、月曜始まりで6つの空白セル）
+    includeWeekends: true,
+    size: 'lg',
+    cellStyle: (date) => {
+      const dayOfWeek = date.getDay();
+      const isFirstWeek = date.getDate() <= 7;
+
+      // 最初の週を強調表示
+      if (isFirstWeek) {
+        return {
+          backgroundColor: '#fff3e0',
+          borderColor: '#f57c00',
+          fontWeight: 'bold',
+        };
+      }
+
+      // 週末は薄い色
+      if (dayOfWeek === 0 || dayOfWeek === 6) {
+        return {
+          backgroundColor: '#f5f5f5',
+          borderColor: '#999',
+        };
+      }
+
+      return {
+        backgroundColor: '#ffffff',
+        borderColor: '#ddd',
+      };
+    },
+  },
+} satisfies Story;

--- a/src/components/calendar-chart/index.stories.tsx
+++ b/src/components/calendar-chart/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { fn } from 'storybook/test';
+import { css } from '@/styled-system/css';
 import { CalendarChart } from '.';
 
 const meta = {
@@ -36,26 +37,19 @@ export const WithCustomStyles = {
       const isToday = date.getDate() === 15;
 
       if (isToday) {
-        return {
-          backgroundColor: '#4facfe',
-          borderColor: '#333',
-          opacity: 1,
-        };
+        return css({ borderColor: 'gray.900' });
       }
 
       if (isHighlighted) {
-        return {
-          backgroundColor: '#f0f8ff',
-          borderColor: '#00d4aa',
-          opacity: 0.8,
-        };
+        return css({
+          backgroundColor: 'entity.powerup',
+          color: 'foreground.alt',
+        });
       }
 
-      return {
-        backgroundColor: '#ffffff',
-        borderColor: '#666',
-        opacity: 0.6,
-      };
+      return css({
+        backgroundColor: 'entity.epicwin',
+      });
     },
   },
 } satisfies Story;
@@ -77,13 +71,12 @@ export const CurrentMonth = {
         date.getFullYear() === today.getFullYear();
 
       if (isToday) {
-        return {
-          backgroundColor: '#ff6b35',
-          borderColor: '#333',
-        };
+        return css({
+          backgroundColor: 'entity.villain',
+        });
       }
 
-      return {};
+      return '';
     },
   },
 } satisfies Story;
@@ -92,13 +85,6 @@ export const WeekdaysOnly = {
   args: {
     month: new Date(2024, 0, 1), // 2024年1月
     includeWeekends: false,
-    cellStyle: (_date) => {
-      // 平日のみなので土日の心配なし
-      return {
-        backgroundColor: '#e8f4fd',
-        borderColor: '#1e88e5',
-      };
-    },
   },
 } satisfies Story;
 
@@ -106,23 +92,6 @@ export const WithWeekends = {
   args: {
     month: new Date(2024, 0, 1), // 2024年1月
     includeWeekends: true,
-    cellStyle: (date) => {
-      const dayOfWeek = date.getDay();
-      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6; // 日曜日または土曜日
-
-      if (isWeekend) {
-        return {
-          backgroundColor: '#ffebee',
-          borderColor: '#e57373',
-          opacity: 0.7,
-        };
-      }
-
-      return {
-        backgroundColor: '#e8f4fd',
-        borderColor: '#1e88e5',
-      };
-    },
   },
 } satisfies Story;
 
@@ -131,27 +100,6 @@ export const WeekendLayoutTest = {
     month: new Date(2024, 5, 1), // 2024年6月（土曜日スタート）
     includeWeekends: true,
     size: 'lg',
-    cellStyle: (date) => {
-      const dayOfWeek = date.getDay();
-
-      // 曜日別に色分け
-      const colors = {
-        0: { bg: '#ffcdd2', border: '#d32f2f' }, // 日曜日（赤）
-        1: { bg: '#e1f5fe', border: '#0277bd' }, // 月曜日（青）
-        2: { bg: '#e8f5e8', border: '#388e3c' }, // 火曜日（緑）
-        3: { bg: '#fff3e0', border: '#f57c00' }, // 水曜日（オレンジ）
-        4: { bg: '#f3e5f5', border: '#7b1fa2' }, // 木曜日（紫）
-        5: { bg: '#fce4ec', border: '#c2185b' }, // 金曜日（ピンク）
-        6: { bg: '#e0f2f1', border: '#00695c' }, // 土曜日（ティール）
-      };
-
-      const color = colors[dayOfWeek as keyof typeof colors];
-
-      return {
-        backgroundColor: color.bg,
-        borderColor: color.border,
-      };
-    },
   },
 } satisfies Story;
 
@@ -160,31 +108,5 @@ export const MondayStartCalendar = {
     month: new Date(2024, 8, 1), // 2024年9月（日曜日スタート、月曜始まりで6つの空白セル）
     includeWeekends: true,
     size: 'lg',
-    cellStyle: (date) => {
-      const dayOfWeek = date.getDay();
-      const isFirstWeek = date.getDate() <= 7;
-
-      // 最初の週を強調表示
-      if (isFirstWeek) {
-        return {
-          backgroundColor: '#fff3e0',
-          borderColor: '#f57c00',
-          fontWeight: 'bold',
-        };
-      }
-
-      // 週末は薄い色
-      if (dayOfWeek === 0 || dayOfWeek === 6) {
-        return {
-          backgroundColor: '#f5f5f5',
-          borderColor: '#999',
-        };
-      }
-
-      return {
-        backgroundColor: '#ffffff',
-        borderColor: '#ddd',
-      };
-    },
   },
 } satisfies Story;

--- a/src/components/calendar-chart/index.stories.tsx
+++ b/src/components/calendar-chart/index.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { fn } from 'storybook/test';
+import { CalendarChart } from '.';
+
+const meta = {
+  component: CalendarChart,
+  args: {
+    month: new Date(2024, 0, 1), // 2024年1月
+    onClick: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CalendarChart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {} satisfies Story;
+
+export const LargeSize = {
+  args: {
+    size: 'lg',
+  },
+} satisfies Story;
+
+export const SmallSize = {
+  args: {
+    size: 'sm',
+  },
+} satisfies Story;
+
+export const WithCustomStyles = {
+  args: {
+    cellStyle: (date, _index) => {
+      const isHighlighted = date.getDate() % 5 === 0;
+      const isToday = date.getDate() === 15;
+
+      if (isToday) {
+        return {
+          backgroundColor: '#4facfe',
+          borderColor: '#333',
+          opacity: 1,
+        };
+      }
+
+      if (isHighlighted) {
+        return {
+          backgroundColor: '#f0f8ff',
+          borderColor: '#00d4aa',
+          opacity: 0.8,
+        };
+      }
+
+      return {
+        backgroundColor: '#ffffff',
+        borderColor: '#666',
+        opacity: 0.6,
+      };
+    },
+  },
+} satisfies Story;
+
+export const CompactSize = {
+  args: {
+    size: 'sm',
+  },
+} satisfies Story;
+
+export const CurrentMonth = {
+  args: {
+    month: new Date(), // 現在の月
+    cellStyle: (date) => {
+      const today = new Date();
+      const isToday =
+        date.getDate() === today.getDate() &&
+        date.getMonth() === today.getMonth() &&
+        date.getFullYear() === today.getFullYear();
+
+      if (isToday) {
+        return {
+          backgroundColor: '#ff6b35',
+          borderColor: '#333',
+        };
+      }
+
+      return {};
+    },
+  },
+} satisfies Story;
+
+export const WeekdaysOnly = {
+  args: {
+    month: new Date(2024, 0, 1), // 2024年1月
+    includeWeekends: false,
+    cellStyle: (_date) => {
+      // 平日のみなので土日の心配なし
+      return {
+        backgroundColor: '#e8f4fd',
+        borderColor: '#1e88e5',
+      };
+    },
+  },
+} satisfies Story;
+
+export const WithWeekends = {
+  args: {
+    month: new Date(2024, 0, 1), // 2024年1月
+    includeWeekends: true,
+    cellStyle: (date) => {
+      const dayOfWeek = date.getDay();
+      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6; // 日曜日または土曜日
+
+      if (isWeekend) {
+        return {
+          backgroundColor: '#ffebee',
+          borderColor: '#e57373',
+          opacity: 0.7,
+        };
+      }
+
+      return {
+        backgroundColor: '#e8f4fd',
+        borderColor: '#1e88e5',
+      };
+    },
+  },
+} satisfies Story;
+
+export const WeekendLayoutTest = {
+  args: {
+    month: new Date(2024, 5, 1), // 2024年6月（土曜日スタート）
+    includeWeekends: true,
+    size: 'lg',
+    cellStyle: (date) => {
+      const dayOfWeek = date.getDay();
+
+      // 曜日別に色分け
+      const colors = {
+        0: { bg: '#ffcdd2', border: '#d32f2f' }, // 日曜日（赤）
+        1: { bg: '#e1f5fe', border: '#0277bd' }, // 月曜日（青）
+        2: { bg: '#e8f5e8', border: '#388e3c' }, // 火曜日（緑）
+        3: { bg: '#fff3e0', border: '#f57c00' }, // 水曜日（オレンジ）
+        4: { bg: '#f3e5f5', border: '#7b1fa2' }, // 木曜日（紫）
+        5: { bg: '#fce4ec', border: '#c2185b' }, // 金曜日（ピンク）
+        6: { bg: '#e0f2f1', border: '#00695c' }, // 土曜日（ティール）
+      };
+
+      const color = colors[dayOfWeek as keyof typeof colors];
+
+      return {
+        backgroundColor: color.bg,
+        borderColor: color.border,
+      };
+    },
+  },
+} satisfies Story;

--- a/src/components/calendar-chart/index.test.tsx
+++ b/src/components/calendar-chart/index.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+// CalendarChartのロジック部分をテストするためのヘルパー関数
+const generateDaysForMonth = (date: Date, includeWeekends: boolean): Date[] => {
+  const year = date.getFullYear();
+  const monthIndex = date.getMonth();
+  const firstDay = new Date(year, monthIndex, 1);
+  const lastDay = new Date(year, monthIndex + 1, 0);
+
+  const days: Date[] = [];
+
+  for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
+    const dayOfWeek = day.getDay();
+
+    if (includeWeekends) {
+      // 全ての曜日を含める
+      days.push(new Date(day));
+    } else {
+      // 月曜日（1）から金曜日（5）のみ
+      if (dayOfWeek >= 1 && dayOfWeek <= 5) {
+        days.push(new Date(day));
+      }
+    }
+  }
+
+  return days;
+};
+
+describe('CalendarChart logic', () => {
+  describe('平日のみ表示', () => {
+    it('2024年1月の平日が正しく生成される', () => {
+      const month = new Date(2024, 0, 1); // 2024年1月
+      const weekdays = generateDaysForMonth(month, false);
+
+      // 2024年1月の平日は23日
+      expect(weekdays).toHaveLength(23);
+
+      // 最初の平日は1月1日（月曜日）
+      expect(weekdays[0].getDate()).toBe(1);
+      expect(weekdays[0].getDay()).toBe(1); // 月曜日
+
+      // 最後の平日は1月31日（水曜日）
+      expect(weekdays[weekdays.length - 1].getDate()).toBe(31);
+      expect(weekdays[weekdays.length - 1].getDay()).toBe(3); // 水曜日
+    });
+
+    it('週末が除外される', () => {
+      const month = new Date(2024, 5, 1); // 2024年6月（土曜日から開始）
+      const weekdays = generateDaysForMonth(month, false);
+
+      // 6月1日（土）と6月2日（日）は除外される
+      expect(weekdays[0].getDate()).toBe(3); // 最初の平日は3日（月曜日）
+      expect(weekdays[0].getDay()).toBe(1); // 月曜日
+
+      // すべて平日であることを確認
+      for (const day of weekdays) {
+        const dayOfWeek = day.getDay();
+        expect(dayOfWeek).toBeGreaterThanOrEqual(1);
+        expect(dayOfWeek).toBeLessThanOrEqual(5);
+      }
+    });
+
+    it('うるう年の2月が正しく処理される', () => {
+      const leapYear = new Date(2024, 1, 1); // 2024年2月（うるう年）
+      const regularYear = new Date(2023, 1, 1); // 2023年2月（平年）
+
+      const leapWeekdays = generateDaysForMonth(leapYear, false);
+      const regularWeekdays = generateDaysForMonth(regularYear, false);
+
+      // うるう年の2月は平年より平日が多い（または同じ）
+      expect(leapWeekdays.length).toBeGreaterThanOrEqual(
+        regularWeekdays.length,
+      );
+
+      // 2024年2月29日が含まれる
+      const feb29 = leapWeekdays.find((day) => day.getDate() === 29);
+      expect(feb29).toBeDefined();
+      expect(feb29?.getDay()).toBe(4); // 2024年2月29日は木曜日
+    });
+
+    it('異なる月で正しい平日数が生成される', () => {
+      const months = [
+        new Date(2024, 0, 1), // 1月
+        new Date(2024, 1, 1), // 2月
+        new Date(2024, 3, 1), // 4月
+        new Date(2024, 10, 1), // 11月
+      ];
+
+      const weekdayCounts = months.map(
+        (month) => generateDaysForMonth(month, false).length,
+      );
+
+      // すべて正の値
+      for (const count of weekdayCounts) {
+        expect(count).toBeGreaterThan(0);
+      }
+
+      // 期待値と照合
+      expect(weekdayCounts[0]).toBe(23); // 1月: 23平日
+      expect(weekdayCounts[1]).toBe(21); // 2月: 21平日
+      expect(weekdayCounts[2]).toBe(22); // 4月: 22平日
+      expect(weekdayCounts[3]).toBe(21); // 11月: 21平日
+    });
+  });
+
+  describe('土日を含む表示', () => {
+    it('2024年1月の全ての日が正しく生成される', () => {
+      const month = new Date(2024, 0, 1); // 2024年1月
+      const allDays = generateDaysForMonth(month, true);
+
+      // 2024年1月は31日
+      expect(allDays).toHaveLength(31);
+
+      // 最初の日は1月1日（月曜日）
+      expect(allDays[0].getDate()).toBe(1);
+      expect(allDays[0].getDay()).toBe(1); // 月曜日
+
+      // 最後の日は1月31日（水曜日）
+      expect(allDays[allDays.length - 1].getDate()).toBe(31);
+      expect(allDays[allDays.length - 1].getDay()).toBe(3); // 水曜日
+    });
+
+    it('土日が含まれる', () => {
+      const month = new Date(2024, 0, 1); // 2024年1月
+      const allDays = generateDaysForMonth(month, true);
+
+      // 土日が含まれていることを確認
+      const weekends = allDays.filter((day) => {
+        const dayOfWeek = day.getDay();
+        return dayOfWeek === 0 || dayOfWeek === 6; // 日曜日または土曜日
+      });
+
+      expect(weekends.length).toBeGreaterThan(0);
+    });
+
+    it('平日のみと土日含む場合で日数が異なる', () => {
+      const month = new Date(2024, 0, 1); // 2024年1月
+      const weekdaysOnly = generateDaysForMonth(month, false);
+      const allDays = generateDaysForMonth(month, true);
+
+      expect(allDays.length).toBeGreaterThan(weekdaysOnly.length);
+      expect(weekdaysOnly).toHaveLength(23); // 平日のみ
+      expect(allDays).toHaveLength(31); // 全日
+    });
+  });
+
+  describe('日付のフォーマット', () => {
+    it('日付オブジェクトが正しい年月日を持つ（平日のみ）', () => {
+      const month = new Date(2024, 2, 1); // 2024年3月
+      const weekdays = generateDaysForMonth(month, false);
+
+      // すべて2024年3月の日付
+      for (const day of weekdays) {
+        expect(day.getFullYear()).toBe(2024);
+        expect(day.getMonth()).toBe(2); // 3月（0ベース）
+      }
+
+      // 日付は昇順
+      for (let i = 1; i < weekdays.length; i++) {
+        expect(weekdays[i].getTime()).toBeGreaterThan(
+          weekdays[i - 1].getTime(),
+        );
+      }
+    });
+
+    it('日付オブジェクトが正しい年月日を持つ（土日含む）', () => {
+      const month = new Date(2024, 2, 1); // 2024年3月
+      const allDays = generateDaysForMonth(month, true);
+
+      // すべて2024年3月の日付
+      for (const day of allDays) {
+        expect(day.getFullYear()).toBe(2024);
+        expect(day.getMonth()).toBe(2); // 3月（0ベース）
+      }
+
+      // 日付は昇順
+      for (let i = 1; i < allDays.length; i++) {
+        expect(allDays[i].getTime()).toBeGreaterThan(allDays[i - 1].getTime());
+      }
+    });
+  });
+});

--- a/src/components/calendar-chart/index.test.tsx
+++ b/src/components/calendar-chart/index.test.tsx
@@ -1,45 +1,5 @@
 import { describe, expect, it } from 'vitest';
-
-// CalendarChartのロジック部分をテストするためのヘルパー関数（月曜始まりカレンダー対応）
-const generateCalendarDaysForMonth = (
-  date: Date,
-  includeWeekends: boolean,
-): (Date | null)[] => {
-  const year = date.getFullYear();
-  const monthIndex = date.getMonth();
-  const firstDay = new Date(year, monthIndex, 1);
-  const lastDay = new Date(year, monthIndex + 1, 0);
-
-  const days: (Date | null)[] = [];
-
-  // 月の最初の日の曜日を取得（日曜日=0を月曜日=0に変換）
-  let firstDayOfWeek = firstDay.getDay();
-  firstDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1; // 月曜日を0とする
-
-  if (includeWeekends) {
-    // 月曜日から始まるカレンダー形式
-    // 最初の週の空白を追加
-    for (let i = 0; i < firstDayOfWeek; i++) {
-      days.push(null);
-    }
-
-    // 月の全ての日を追加
-    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-      days.push(new Date(day));
-    }
-  } else {
-    // 平日のみの場合は空白なしで月曜日から金曜日のみ
-    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-      const dayOfWeek = day.getDay();
-      // 月曜日（1）から金曜日（5）のみ
-      if (dayOfWeek >= 1 && dayOfWeek <= 5) {
-        days.push(new Date(day));
-      }
-    }
-  }
-
-  return days;
-};
+import { generateCalendarDaysForMonth } from '.';
 
 describe('CalendarChart logic', () => {
   describe('平日のみ表示', () => {

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -160,25 +160,37 @@ export const CalendarChart = ({
   size = 'md',
   includeWeekends = true,
 }: CalendarChartProps) => {
-  // 月ごとの日付データを生成
-  const generateDaysForMonth = (
+  // 月ごとの日付データを生成（月曜始まりのカレンダー形式）
+  const generateCalendarDaysForMonth = (
     date: Date,
     includeWeekends: boolean,
-  ): Date[] => {
+  ): (Date | null)[] => {
     const year = date.getFullYear();
     const monthIndex = date.getMonth();
     const firstDay = new Date(year, monthIndex, 1);
     const lastDay = new Date(year, monthIndex + 1, 0);
 
-    const days: Date[] = [];
+    const days: (Date | null)[] = [];
 
-    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-      const dayOfWeek = day.getDay();
+    // 月の最初の日の曜日を取得（日曜日=0を月曜日=0に変換）
+    let firstDayOfWeek = firstDay.getDay();
+    firstDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1; // 月曜日を0とする
 
-      if (includeWeekends) {
-        // 全ての曜日を含める
+    if (includeWeekends) {
+      // 月曜日から始まるカレンダー形式
+      // 最初の週の空白を追加
+      for (let i = 0; i < firstDayOfWeek; i++) {
+        days.push(null);
+      }
+
+      // 月の全ての日を追加
+      for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
         days.push(new Date(day));
-      } else {
+      }
+    } else {
+      // 平日のみの場合は空白なしで月曜日から金曜日のみ
+      for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
+        const dayOfWeek = day.getDay();
         // 月曜日（1）から金曜日（5）のみ
         if (dayOfWeek >= 1 && dayOfWeek <= 5) {
           days.push(new Date(day));
@@ -189,7 +201,7 @@ export const CalendarChart = ({
     return days;
   };
 
-  const days = generateDaysForMonth(month, includeWeekends);
+  const days = generateCalendarDaysForMonth(month, includeWeekends);
   const columnsCount = includeWeekends ? 7 : 5;
   const classes = calendarChart({ size });
 
@@ -201,6 +213,17 @@ export const CalendarChart = ({
       }}
     >
       {days.map((date, index) => {
+        // 空白セル（null）の場合
+        if (date === null) {
+          return (
+            <div
+              key={`empty-${index}`}
+              className={classes.cell || ''}
+              style={{ visibility: 'hidden' }}
+            />
+          );
+        }
+
         const style = cellStyle?.(date, index);
         return (
           <CalendarCell

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -91,16 +91,17 @@ const generateCalendarDaysForMonth = (
     }
 
     // 月の全ての日を追加
-    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-      days.push(new Date(day));
+    for (let date = 1; date <= lastDay.getDate(); date++) {
+      days.push(new Date(year, monthIndex, date));
     }
   } else {
     // 平日のみの場合は空白なしで月曜日から金曜日のみ
-    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-      const dayOfWeek = day.getDay();
+    for (let date = 1; date <= lastDay.getDate(); date++) {
+      const currentDay = new Date(year, monthIndex, date);
+      const dayOfWeek = currentDay.getDay();
       // 月曜日（1）から金曜日（5）のみ
       if (dayOfWeek >= 1 && dayOfWeek <= 5) {
-        days.push(new Date(day));
+        days.push(currentDay);
       }
     }
   }

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -68,7 +68,7 @@ const calendarChart = sva({
 /**
  * 月ごとの日付データを生成（月曜始まりのカレンダー形式）
  */
-const generateCalendarDaysForMonth = (
+export const generateCalendarDaysForMonth = (
   date: Date,
   includeWeekends: boolean,
 ): (Date | null)[] => {

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useTapFeeling } from '@/hooks/feeling';
+import { css, cx, sva } from '@/styled-system/css';
+import { pixelBorder } from '@/styled-system/patterns';
+
+type Size = 'sm' | 'md' | 'lg';
+
+const calendarChart = sva({
+  slots: ['container', 'cell'],
+  base: {
+    container: {
+      display: 'grid',
+      width: '[fit-content]',
+    },
+    cell: {
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textStyle: 'Body.primary',
+      fontSize: '12px',
+      backgroundColor: 'background',
+      _hover: {
+        backgroundColor: 'interactive.background.hover',
+      },
+      _active: {
+        transform: 'scale(0.95)',
+      },
+    },
+  },
+  variants: {
+    size: {
+      sm: {
+        container: {
+          gap: '[2px]',
+        },
+        cell: {
+          width: '[32px]',
+          height: '[32px]',
+        },
+      },
+      md: {
+        container: {
+          gap: '[4px]',
+        },
+        cell: {
+          width: '[40px]',
+          height: '[40px]',
+        },
+      },
+      lg: {
+        container: {
+          gap: '[8px]',
+        },
+        cell: {
+          width: '[48px]',
+          height: '[48px]',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export interface CalendarChartProps {
+  /**
+   * 表示する月
+   */
+  month: Date;
+  /**
+   * 日のアイテムがクリックされた時のイベントハンドラー
+   * @param date クリックされた日付
+   * @param index その日のインデックス（月曜日が0、土日含む場合は日曜日が0）
+   */
+  onClick?: (date: Date, index: number) => void;
+  /**
+   * 各日のセルに適用するカスタムスタイル
+   * セルの状態や日付に基づいてスタイルを動的に決定可能
+   */
+  cellStyle?: (
+    date: Date,
+    index: number,
+  ) => {
+    backgroundColor?: string;
+    borderColor?: string;
+    opacity?: number;
+    [key: string]: string | number | undefined;
+  };
+  /**
+   * セルのサイズとギャップサイズ
+   * @default 'md'
+   */
+  size?: Size;
+  /**
+   * 土日を含めて表示するかどうか
+   * @default true
+   */
+  includeWeekends?: boolean;
+}
+
+interface CalendarCellProps {
+  date: Date;
+  index: number;
+  size: Size;
+  cellClassName: string;
+  style?: {
+    backgroundColor?: string;
+    borderColor?: string;
+    opacity?: number;
+    [key: string]: string | number | undefined;
+  };
+  onClick?: (date: Date, index: number) => void;
+}
+
+const CalendarCell = ({
+  date,
+  index,
+  cellClassName,
+  style,
+  onClick,
+}: CalendarCellProps) => {
+  const feeling = useTapFeeling();
+
+  const handleClick = () => {
+    onClick?.(date, index);
+  };
+
+  return (
+    <button
+      {...feeling.props}
+      onClick={handleClick}
+      className={cx(
+        pixelBorder({
+          borderWidth: 1,
+          borderColor: 'interactive.border.alt',
+        }),
+        cellClassName,
+        css(feeling.cssRaw),
+      )}
+      style={{
+        backgroundColor: style?.backgroundColor,
+        opacity: style?.opacity,
+      }}
+    >
+      {date.getDate()}
+    </button>
+  );
+};
+
+/**
+ * 月ごとのカレンダーを表示するカレンダーチャートコンポーネント
+ */
+export const CalendarChart = ({
+  month,
+  onClick,
+  cellStyle,
+  size = 'md',
+  includeWeekends = true,
+}: CalendarChartProps) => {
+  // 月ごとの日付データを生成
+  const generateDaysForMonth = (
+    date: Date,
+    includeWeekends: boolean,
+  ): Date[] => {
+    const year = date.getFullYear();
+    const monthIndex = date.getMonth();
+    const firstDay = new Date(year, monthIndex, 1);
+    const lastDay = new Date(year, monthIndex + 1, 0);
+
+    const days: Date[] = [];
+
+    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
+      const dayOfWeek = day.getDay();
+
+      if (includeWeekends) {
+        // 全ての曜日を含める
+        days.push(new Date(day));
+      } else {
+        // 月曜日（1）から金曜日（5）のみ
+        if (dayOfWeek >= 1 && dayOfWeek <= 5) {
+          days.push(new Date(day));
+        }
+      }
+    }
+
+    return days;
+  };
+
+  const days = generateDaysForMonth(month, includeWeekends);
+  const columnsCount = includeWeekends ? 7 : 5;
+  const classes = calendarChart({ size });
+
+  return (
+    <div
+      className={classes.container}
+      style={{
+        gridTemplateColumns: `repeat(${columnsCount}, 1fr)`,
+      }}
+    >
+      {days.map((date, index) => {
+        const style = cellStyle?.(date, index);
+        return (
+          <CalendarCell
+            key={date.toISOString()}
+            date={date}
+            index={index}
+            size={size}
+            cellClassName={classes.cell || ''}
+            style={style}
+            onClick={onClick}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -77,18 +77,10 @@ export interface CalendarChartProps {
    */
   onClick?: (date: Date, index: number) => void;
   /**
-   * 各日のセルに適用するカスタムスタイル
-   * セルの状態や日付に基づいてスタイルを動的に決定可能
+   * 各日のセルに適用するカスタムクラス名
+   * セルの状態や日付に基づいてクラス名を動的に決定可能
    */
-  cellStyle?: (
-    date: Date,
-    index: number,
-  ) => {
-    backgroundColor?: string;
-    borderColor?: string;
-    opacity?: number;
-    [key: string]: string | number | undefined;
-  };
+  cellStyle?: (date: Date, index: number) => string;
   /**
    * セルのサイズとギャップサイズ
    * @default 'md'
@@ -106,12 +98,7 @@ interface CalendarCellProps {
   index: number;
   size: Size;
   cellClassName: string;
-  style?: {
-    backgroundColor?: string;
-    borderColor?: string;
-    opacity?: number;
-    [key: string]: string | number | undefined;
-  };
+  customClassName?: string;
   onClick?: (date: Date, index: number) => void;
 }
 
@@ -119,7 +106,7 @@ const CalendarCell = ({
   date,
   index,
   cellClassName,
-  style,
+  customClassName,
   onClick,
 }: CalendarCellProps) => {
   const feeling = useTapFeeling();
@@ -139,11 +126,8 @@ const CalendarCell = ({
         }),
         cellClassName,
         css(feeling.cssRaw),
+        customClassName,
       )}
-      style={{
-        backgroundColor: style?.backgroundColor,
-        opacity: style?.opacity,
-      }}
     >
       {date.getDate()}
     </button>
@@ -224,7 +208,7 @@ export const CalendarChart = ({
           );
         }
 
-        const style = cellStyle?.(date, index);
+        const customClassName = cellStyle?.(date, index);
         return (
           <CalendarCell
             key={date.toISOString()}
@@ -232,7 +216,7 @@ export const CalendarChart = ({
             index={index}
             size={size}
             cellClassName={classes.cell || ''}
-            style={style}
+            customClassName={customClassName}
             onClick={onClick}
           />
         );

--- a/src/components/calendar-chart/index.tsx
+++ b/src/components/calendar-chart/index.tsx
@@ -65,6 +65,49 @@ const calendarChart = sva({
   },
 });
 
+/**
+ * 月ごとの日付データを生成（月曜始まりのカレンダー形式）
+ */
+const generateCalendarDaysForMonth = (
+  date: Date,
+  includeWeekends: boolean,
+): (Date | null)[] => {
+  const year = date.getFullYear();
+  const monthIndex = date.getMonth();
+  const firstDay = new Date(year, monthIndex, 1);
+  const lastDay = new Date(year, monthIndex + 1, 0);
+
+  const days: (Date | null)[] = [];
+
+  // 月の最初の日の曜日を取得（日曜日=0を月曜日=0に変換）
+  let firstDayOfWeek = firstDay.getDay();
+  firstDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1; // 月曜日を0とする
+
+  if (includeWeekends) {
+    // 月曜日から始まるカレンダー形式
+    // 最初の週の空白を追加
+    for (let i = 0; i < firstDayOfWeek; i++) {
+      days.push(null);
+    }
+
+    // 月の全ての日を追加
+    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
+      days.push(new Date(day));
+    }
+  } else {
+    // 平日のみの場合は空白なしで月曜日から金曜日のみ
+    for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
+      const dayOfWeek = day.getDay();
+      // 月曜日（1）から金曜日（5）のみ
+      if (dayOfWeek >= 1 && dayOfWeek <= 5) {
+        days.push(new Date(day));
+      }
+    }
+  }
+
+  return days;
+};
+
 export interface CalendarChartProps {
   /**
    * 表示する月
@@ -144,47 +187,6 @@ export const CalendarChart = ({
   size = 'md',
   includeWeekends = true,
 }: CalendarChartProps) => {
-  // 月ごとの日付データを生成（月曜始まりのカレンダー形式）
-  const generateCalendarDaysForMonth = (
-    date: Date,
-    includeWeekends: boolean,
-  ): (Date | null)[] => {
-    const year = date.getFullYear();
-    const monthIndex = date.getMonth();
-    const firstDay = new Date(year, monthIndex, 1);
-    const lastDay = new Date(year, monthIndex + 1, 0);
-
-    const days: (Date | null)[] = [];
-
-    // 月の最初の日の曜日を取得（日曜日=0を月曜日=0に変換）
-    let firstDayOfWeek = firstDay.getDay();
-    firstDayOfWeek = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1; // 月曜日を0とする
-
-    if (includeWeekends) {
-      // 月曜日から始まるカレンダー形式
-      // 最初の週の空白を追加
-      for (let i = 0; i < firstDayOfWeek; i++) {
-        days.push(null);
-      }
-
-      // 月の全ての日を追加
-      for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-        days.push(new Date(day));
-      }
-    } else {
-      // 平日のみの場合は空白なしで月曜日から金曜日のみ
-      for (let day = firstDay; day <= lastDay; day.setDate(day.getDate() + 1)) {
-        const dayOfWeek = day.getDay();
-        // 月曜日（1）から金曜日（5）のみ
-        if (dayOfWeek >= 1 && dayOfWeek <= 5) {
-          days.push(new Date(day));
-        }
-      }
-    }
-
-    return days;
-  };
-
   const days = generateCalendarDaysForMonth(month, includeWeekends);
   const columnsCount = includeWeekends ? 7 : 5;
   const classes = calendarChart({ size });


### PR DESCRIPTION
## Summary
- 月ごとのカレンダー表示を行うCalendarChartコンポーネントを新規追加
- 月曜始まりのカレンダー形式に対応
- 平日のみ表示と土日を含む表示の切り替えが可能
- PandaCSSベースのスタイリングを実装
- パフォーマンス最適化を実施

## 主な機能
- `CalendarChart`コンポーネント：月ごとのカレンダー表示
- サイズ（sm/md/lg）とレイアウト（平日のみ/土日含む）の選択
- カスタムスタイリング機能
- テストファイルとStorybookストーリーを完備

## Test plan
- [x] pnpm test でユニットテストが通ることを確認
- [x] pnpm storybook でStorybook上での表示確認
- [x] 各サイズ（sm/md/lg）での表示確認
- [x] 平日のみ表示と土日含む表示の動作確認
- [x] カスタムスタイルの適用確認

🤖 Generated with [Claude Code](https://claude.ai/code)