### PR TITLE
fix: 複数のUI改善

### DIFF
--- a/src/app/(private)/me/_components/config-button/index.tsx
+++ b/src/app/(private)/me/_components/config-button/index.tsx
@@ -4,7 +4,7 @@ import { signOut } from '@/app/(private)/_actions/signout';
 import { Logout, MoreVertical } from '@/assets/icons';
 import { IconButton } from '@/components/icon-button';
 import { Popover } from '@/components/popover';
-import { css } from '@/styled-system/css';
+import { css, cx } from '@/styled-system/css';
 import { pixelBorder } from '@/styled-system/patterns';
 
 export const ConfigButton = () => {
@@ -27,7 +27,10 @@ export const ConfigButton = () => {
             {...getFloatingProps()}
             style={floatingStyles}
             ref={refs.setFloating}
-            className={pixelBorder({})}
+            className={cx(
+              pixelBorder({}),
+              css({ backgroundColor: 'background' }),
+            )}
           >
             <button
               type="button"

--- a/src/app/(private)/me/_components/log-section/index.tsx
+++ b/src/app/(private)/me/_components/log-section/index.tsx
@@ -14,7 +14,7 @@ export const LogSection = ({
   const [selectedDate, setSelectedDate] = useState(
     () => weeklyAchievement.find((d) => d.isToday)?.dateString,
   );
-  const [showPosNegRatio, setShowPosNegRatio] = useState(false);
+  const [showPosNegRatio, setShowPosNegRatio] = useState(true);
 
   const hasPosNegData = useMemo(
     () => weeklyAchievement.some((d) => d.posNegScore !== undefined),


### PR DESCRIPTION
## 概要
- グラフに魔力測定をデフォルトで表示するように変更
- ログアウトボタンのポップオーバーに背景色を追加してUIを改善

## 変更内容
- グラフの魔力測定表示のデフォルト値を `false` から `true` に変更
- ログアウトボタンのポップオーバーに `backgroundColor: 'background'` を追加

## テスト計画
- [ ] グラフページで魔力測定がデフォルトで表示されることを確認
- [ ] ログアウトボタンのポップオーバーが適切な背景色で表示されることを確認
- [ ] ログアウト機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)