### PR TITLE
fix: 魔力測定チェックボックスを常に表示

### DIFF
--- a/src/app/(private)/me/_components/log-section/index.tsx
+++ b/src/app/(private)/me/_components/log-section/index.tsx
@@ -16,10 +16,6 @@ export const LogSection = ({
   );
   const [showPosNegRatio, setShowPosNegRatio] = useState(true);
 
-  const hasPosNegData = useMemo(
-    () => weeklyAchievement.some((d) => d.posNegScore !== undefined),
-    [weeklyAchievement],
-  );
   const chartData = useMemo(
     () =>
       weeklyAchievement.map((d) => ({
@@ -53,24 +49,22 @@ export const LogSection = ({
         })}
       >
         <h2 className={css({ textStyle: 'Heading.primary' })}>冒険ログ</h2>
-        {hasPosNegData && (
-          <label
-            className={css({
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              cursor: 'pointer',
-              textStyle: 'Body.secondary',
-            })}
-          >
-            <input
-              type="checkbox"
-              checked={showPosNegRatio}
-              onChange={(e) => setShowPosNegRatio(e.target.checked)}
-            />
-            魔力測定
-          </label>
-        )}
+        <label
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            cursor: 'pointer',
+            textStyle: 'Body.secondary',
+          })}
+        >
+          <input
+            type="checkbox"
+            checked={showPosNegRatio}
+            onChange={(e) => setShowPosNegRatio(e.target.checked)}
+          />
+          魔力測定
+        </label>
       </div>
       <TimeSeriesChart
         onClickBar={setSelectedDate}


### PR DESCRIPTION
## Summary
- ログセクションで魔力測定チェックボックスを常に表示されるように修正
- posNegDataの存在チェック（hasPosNegData）を削除
- UIの一貫性を向上

## Test plan
- [x] ログセクションが正常に表示される
- [x] 魔力測定チェックボックスが常に表示される
- [x] チェックボックスのオン/オフ機能が動作する
- [x] TypeCheckとLintが通る

🤖 Generated with [Claude Code](https://claude.ai/code)