### PR TITLE
fix: Update MCP config key from 'transport' to 'type'

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
       ]
     },
     "storybook-mcp": {
-      "transport": "http",
+      "type": "http",
       "url": "http://localhost:6006/mcp"
     },
     "next-devtools": {


### PR DESCRIPTION
## Summary
- Update Storybook MCP server configuration to use the correct 'type' key instead of 'transport'
- This aligns with the current MCP specification format

## Test plan
- [x] Configuration change verified
- [ ] Confirm Storybook MCP server connects properly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)