### PR TITLE
feat: CI に integration test を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
         cache: pnpm
     - name: Install dependencies
       run: pnpm install
+    - name: Start database
+      run: docker compose up -d
+    - name: Wait for database
+      run: |
+        until docker compose exec -T db mysqladmin ping -h localhost -proot --silent; do
+          sleep 1
+        done
     - name: Install Playwright browsers
       run: pnpm --filter @superbetter/web exec playwright install --with-deps chromium
     - name: Type check
@@ -23,3 +30,5 @@ jobs:
       run: pnpm check
     - name: Test
       run: pnpm test:unit
+    - name: Integration Test
+      run: pnpm test:integration


### PR DESCRIPTION
## Summary
- docker compose でMySQLを起動
- DB起動待機ステップを追加
- `pnpm test:integration` を実行するステップを追加

## Test plan
- [ ] CIワークフローが正常に実行されることを確認
- [ ] Integration testが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)