### PR TITLE
fix: Android PWAでの表示崩れを修正

### DIFF
--- a/apps/web/src/app/(private)/layout.tsx
+++ b/apps/web/src/app/(private)/layout.tsx
@@ -18,6 +18,7 @@ const Layout = async ({ children }: PropsWithChildren) => {
           position: 'sticky',
           bottom: 0,
           padding: '8px',
+          pb: '[calc(8px + env(safe-area-inset-bottom))]',
           backgroundColor: 'background',
         })}
       >

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { GlassScreenProvider, Toaster, ToastProvider } from '@superbetter/ui';
 import { pixelMPlus } from '@/fonts';
@@ -44,6 +44,14 @@ export const metadata: Metadata = {
     },
     description: APP_DESCRIPTION,
   },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- Android PWAで下部のボタンが見切れる問題を修正
- Android PWAでリストページに余分なスクロールが発生する問題を修正

## Changes
1. **`apps/web/src/app/layout.tsx`**
   - Next.jsの`viewport`設定を追加
   - `viewportFit: 'cover'`を設定してsafe-area環境変数にアクセス可能に

2. **`apps/web/src/app/(private)/layout.tsx`**
   - FooterNavigationの`padding-bottom`に`env(safe-area-inset-bottom)`を追加
   - これによりセーフエリアを考慮した余白が確保される

## Problem
- `quests/[id]`, `missions/[id]`, `villains/[id]`, `powerups/[id]`の詳細ページで下部のボタンが画面外に見切れていた
- リストページで不要なスクロールが発生していた

## Solution
- `viewportFit: 'cover'`によりWebページがノッチやホームインジケーターの領域まで拡張され、`env(safe-area-inset-*)`変数が利用可能になる
- FooterNavigationに動的な下部余白を追加することで、デバイスのセーフエリアに応じて適切な余白が設定される

## Test plan
- [ ] Android PWAで詳細ページ（quests/[id]等）の下部ボタンが正常に表示されること
- [ ] Android PWAでリストページの余分なスクロールが発生しないこと
- [ ] iOS PWAで表示が崩れないこと
- [ ] 通常のブラウザ表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)