### PR TITLE
fix: add require and default exports to @superbetter/ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ __screenshots__
 
 # Turborepo
 .turbo
+.vercel
+.env*.local

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,19 +6,27 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./preset": {
       "types": "./src/preset.ts",
-      "import": "./dist/preset.js"
+      "import": "./dist/preset.js",
+      "require": "./dist/preset.js",
+      "default": "./dist/preset.js"
     },
     "./hooks": {
       "types": "./src/hooks/index.ts",
-      "import": "./dist/hooks/index.js"
+      "import": "./dist/hooks/index.js",
+      "require": "./dist/hooks/index.js",
+      "default": "./dist/hooks/index.js"
     },
     "./icons": {
       "types": "./src/components/icons/index.ts",
-      "import": "./dist/icons/index.js"
+      "import": "./dist/icons/index.js",
+      "require": "./dist/icons/index.js",
+      "default": "./dist/icons/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- `packages/ui/package.json`のexportsに`require`と`default`条件を追加
- Vercelビルドで`@superbetter/ui/preset`が解決できない問題を修正
- PandaCSSがconfigをロードする際のモジュール解決エラーを解消

## Test plan
- [x] ローカルで`node -e "console.log(require.resolve('@superbetter/ui/preset'))"`が成功することを確認
- [x] ローカルで`pnpm prepare`が成功することを確認
- [x] Vercel Previewデプロイが成功することを確認
- [x] Vercel Productionデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)