### PR TITLE
fix(ci): VRTとVRT-UIのPRコメントが上書きし合う問題を修正

### DIFF
--- a/.github/workflows/vrt-ui.yml
+++ b/.github/workflows/vrt-ui.yml
@@ -130,7 +130,7 @@ jobs:
               status = 'Passed';
             }
 
-            let body = `## ${status === 'Passed' ? '✅' : status === 'Failed' ? '⚠️' : '❌'} Visual Regression Test Results (UI Package)\n\n`;
+            let body = `<!-- VRT-UI-COMMENT -->\n## ${status === 'Passed' ? '✅' : status === 'Failed' ? '⚠️' : '❌'} Visual Regression Test Results (UI Package)\n\n`;
             body += `| Total | Passed | Failed | Skipped |\n`;
             body += `|-------|--------|--------|--------|\n`;
             body += `| ${total} | ${passed} | ${failed} | ${skipped} |\n\n`;
@@ -159,7 +159,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Visual Regression Test Results (UI Package)')
+              comment.body.includes('<!-- VRT-UI-COMMENT -->')
             );
 
             if (botComment) {

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -120,7 +120,7 @@ jobs:
               status = 'Passed';
             }
 
-            let body = `## ${status === 'Passed' ? '✅' : status === 'Failed' ? '⚠️' : '❌'} Visual Regression Test Results\n\n`;
+            let body = `<!-- VRT-WEB-COMMENT -->\n## ${status === 'Passed' ? '✅' : status === 'Failed' ? '⚠️' : '❌'} Visual Regression Test Results (Web App)\n\n`;
             body += `| Total | Passed | Failed | Skipped |\n`;
             body += `|-------|--------|--------|--------|\n`;
             body += `| ${total} | ${passed} | ${failed} | ${skipped} |\n\n`;
@@ -149,7 +149,7 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Visual Regression Test Results')
+              comment.body.includes('<!-- VRT-WEB-COMMENT -->')
             );
 
             if (botComment) {


### PR DESCRIPTION
## Summary
- VRTとVRT-UIワークフローのPRコメントが互いに上書きし合う問題を修正
- 各ワークフローにユニークなHTMLコメントマーカーを追加して識別を明確化
- vrt.yml: `<!-- VRT-WEB-COMMENT -->`、vrt-ui.yml: `<!-- VRT-UI-COMMENT -->`

## 原因
`vrt.yml`のコメント検索条件 `'Visual Regression Test Results'` が、`vrt-ui.yml`のコメント `'Visual Regression Test Results (UI Package)'` にもマッチしていた

## Test plan
- [ ] PRでVRTとVRT-UIの両方が実行される変更をプッシュ
- [ ] 両方のコメントが別々に作成・更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)