### PR TITLE
fix: プライベートレイアウトのスクロール高さを修正

### DIFF
--- a/apps/web/src/app/(private)/layout.tsx
+++ b/apps/web/src/app/(private)/layout.tsx
@@ -12,13 +12,12 @@ const Layout = async ({ children }: PropsWithChildren) => {
         height: '[100%]',
       })}
     >
-      {children}
+      <div className={css({ flex: '1', overflow: 'hidden', minHeight: '[0]' })}>
+        {children}
+      </div>
       <div
         className={css({
-          position: 'sticky',
-          bottom: 0,
           padding: '8px',
-          pb: '[calc(8px + env(safe-area-inset-bottom))]',
           backgroundColor: 'background',
         })}
       >


### PR DESCRIPTION
## Summary
- childrenをflex: 1のdivでラップし、overflow: hiddenとminHeight: 0を設定
- スクロール高さが正しく計算されるように修正
- ナビゲーションバーからstickyポジショニングを削除

## Test plan
- [ ] プライベートページでスクロールが正しく動作することを確認
- [ ] ナビゲーションバーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)