### PR TITLE
fix: テストヘルパーの日付計算をJST基準に修正してFlaky testを解消

### DIFF
--- a/apps/web/src/test/helpers/date-helpers.ts
+++ b/apps/web/src/test/helpers/date-helpers.ts
@@ -1,11 +1,22 @@
+import { TZDate } from '@date-fns/tz';
+
 /**
- * N日前の日付を取得（UTC midnight）
+ * N日前の日付を取得（JST基準）
+ * プロダクションコードがJSTで「今日」「昨日」を判定するため、
+ * テストもJSTベースで日付を生成する
  */
 export const getDaysAgo = (days: number): Date => {
-  const now = new Date();
-  now.setUTCDate(now.getUTCDate() - days);
-  now.setUTCHours(0, 0, 0, 0);
-  return now;
+  const nowJST = new TZDate(new Date(), 'Asia/Tokyo');
+  const targetJST = new TZDate(
+    nowJST.getFullYear(),
+    nowJST.getMonth(),
+    nowJST.getDate() - days,
+    12,
+    0,
+    0,
+    'Asia/Tokyo',
+  );
+  return new Date(targetJST.toISOString());
 };
 
 export const getToday = (): Date => getDaysAgo(0);


### PR DESCRIPTION
## Summary
- テストヘルパー `getDaysAgo` 関数の日付計算をUTC基準からJST基準に修正
- CIの実行タイミング（UTC 15:00-18:00頃 = JST 0:00-3:00頃）でUTCとJSTの日付がずれることにより発生していたFlaky testを解消
- `@date-fns/tz` の `TZDate` を使用して正確にJSTで日付を計算

## Problem
Integration Testがランダムに失敗する問題が発生していました。原因は以下の通りです：

1. プロダクションコードは `toJSTDateString` でJST基準で「今日」「昨日」を判定
2. テストヘルパーはUTC midnight基準で日付を生成
3. CIがUTC 15:00-18:00（JST 0:00-3:00）に実行されると、UTCとJSTで日付がずれる
4. 結果として「昨日のデータ」として作成したテストデータが、JSTでは「今日」と判定されてテストが失敗

## Solution
- `getDaysAgo` 関数をJST基準に変更
- JST正午（12:00）を基準にすることで日付境界の影響を軽減

## Modified Files
- `apps/web/src/test/helpers/date-helpers.ts`

## Test Plan
- [ ] Integration Testが安定して通ることを確認
- [ ] CIでテストが成功することを確認

Closes #732

---
Generated with [Claude Code](https://claude.ai/code)