### PR TITLE
fix: Vercelビルドのflaky問題を修正し、gh-pagesのデプロイを除外

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
   ],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["prepare", "^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {
@@ -36,7 +36,8 @@
       "outputs": ["storybook-static/**"]
     },
     "prepare": {
-      "dependsOn": ["^prepare"]
+      "dependsOn": ["^prepare"],
+      "outputs": ["src/styled-system/**", "dist/**"]
     },
     "drizzle:gen": {},
     "drizzle:migrate": {},

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Vercelデプロイ時のflakyビルド問題を修正
- gh-pagesブランチのpreviewデプロイを無効化

## Changes
### turbo.json
- `build`タスクに`prepare`依存を追加し、PandaCSSのスタイル生成が確実に実行されるように修正
- `prepare`タスクに`outputs`を追加してキャッシュを有効化

### vercel.json（新規作成）
- `gh-pages`ブランチのデプロイを無効化（Storybookのドキュメント用ブランチのため、Vercelでのデプロイは不要）

## Test plan
- [ ] Vercelでのビルドが安定して成功することを確認
- [ ] gh-pagesブランチにpushしてもVercelのpreviewデプロイが作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)