### PR TITLE
fix: Android PWAでのviewport高さ問題を改善

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -52,6 +52,7 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover',
+  interactiveWidget: 'resizes-content',
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- Android Chrome PWAでビューポートの高さが正しく計算されない問題に対処
- `interactiveWidget: 'resizes-content'`をviewportメタに追加
- キーボード表示時のビューポートの挙動を改善

## 変更内容
viewportの設定に`interactiveWidget: 'resizes-content'`を追加しました。これにより、Android PWAでキーボードが表示された際にビューポートが適切にリサイズされます。

## 関連
Closes #733

## References
- [Fix for viewport height change on Chrome on Android - Next.js Discussion #63724](https://github.com/vercel/next.js/discussions/63724)
- [Next.js generateViewport Documentation](https://nextjs.org/docs/app/api-reference/functions/generate-viewport)

## Test plan
- [ ] Android端末でPWAとしてインストールしてテスト
- [ ] キーボード表示時にビューポートが正しくリサイズされることを確認
- [ ] 既存の表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)