### PR TITLE
fix: 各ページのレイアウトとスクロール挙動を改善

### DIFF
--- a/apps/web/src/app/(private)/missions/[missionId]/page.tsx
+++ b/apps/web/src/app/(private)/missions/[missionId]/page.tsx
@@ -17,70 +17,54 @@ const Page = async (props: PageProps<'/missions/[missionId]'>) => {
       className={css({
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'space-between',
-        gap: '16px',
+        gap: '12px',
         height: '[100%]',
         overflow: 'auto',
       })}
     >
+      <Header />
       <div
         className={css({
           display: 'flex',
           flexDirection: 'column',
           gap: '12px',
+          padding: '8px',
         })}
       >
-        <Header />
-        <div
-          className={css({
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '12px',
-            padding: '8px',
-          })}
-        >
-          <h1 className={css({ textStyle: 'Heading.primary' })}>
-            {mission.data.title}
-          </h1>
-          <div>
-            {mission.data.description?.split('\n').map((line, i) => (
-              <p
-                key={i}
-                className={css({
-                  textAlign: 'center',
-                  textStyle: 'Body.secondary',
-                })}
-              >
-                {line}
-              </p>
-            ))}
-          </div>
-        </div>
-        <div
-          className={css({
-            backgroundColor: 'background',
-            position: 'sticky',
-            top: 0,
-            padding: '8px',
-          })}
-        >
-          <MissionEntities
-            items={mission.data.missionConditions.map((mc) => ({
-              id: mc.id,
-              itemType: mc.itemType,
-              completed: mc.completed,
-            }))}
-          />
-        </div>
-        <div
-          className={css({
-            flex: '1',
-            minHeight: '[0]',
-          })}
-        >
-          <MissionForm entities={entities} />
+        <h1 className={css({ textStyle: 'Heading.primary' })}>
+          {mission.data.title}
+        </h1>
+        <div>
+          {mission.data.description?.split('\n').map((line, i) => (
+            <p
+              key={i}
+              className={css({
+                textAlign: 'center',
+                textStyle: 'Body.secondary',
+              })}
+            >
+              {line}
+            </p>
+          ))}
         </div>
       </div>
+      <div
+        className={css({
+          backgroundColor: 'background',
+          position: 'sticky',
+          top: 0,
+          padding: '8px',
+        })}
+      >
+        <MissionEntities
+          items={mission.data.missionConditions.map((mc) => ({
+            id: mc.id,
+            itemType: mc.itemType,
+            completed: mc.completed,
+          }))}
+        />
+      </div>
+      <MissionForm entities={entities} />
     </main>
   );
 };

--- a/apps/web/src/app/(private)/page.tsx
+++ b/apps/web/src/app/(private)/page.tsx
@@ -21,8 +21,6 @@ export default async function Home() {
       className={css({
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'space-between',
-        height: '[100%]',
       })}
     >
       <div

--- a/apps/web/src/app/(private)/powerups/page.tsx
+++ b/apps/web/src/app/(private)/powerups/page.tsx
@@ -14,7 +14,8 @@ const Page = async () => {
       className={css({
         display: 'flex',
         flexDirection: 'column',
-        flex: '1',
+        height: '[100%]',
+        overflow: 'auto',
       })}
     >
       <div

--- a/apps/web/src/app/(private)/quests/page.tsx
+++ b/apps/web/src/app/(private)/quests/page.tsx
@@ -14,7 +14,8 @@ const Page = async () => {
       className={css({
         display: 'flex',
         flexDirection: 'column',
-        flex: '1',
+        height: '[100%]',
+        overflow: 'auto',
       })}
     >
       <div

--- a/apps/web/src/app/(private)/villains/page.tsx
+++ b/apps/web/src/app/(private)/villains/page.tsx
@@ -13,8 +13,9 @@ const Page = async () => {
     <main
       className={css({
         display: 'flex',
-        flex: '1',
         flexDirection: 'column',
+        height: '[100%]',
+        overflow: 'auto',
       })}
     >
       <div


### PR DESCRIPTION
## Summary
- missions詳細ページのネスト構造を簡素化し、gapを調整
- powerups, quests, villainsページで`flex: 1`から`height: 100%` + `overflow: auto`に変更してスクロール挙動を改善
- ホームページから不要な`justifyContent: 'space-between'`と`height: '[100%]'`スタイルを削除
- next-env.d.tsの型定義パスをNext.js最新形式に更新

## Test plan
- [ ] 各ページ（quests, powerups, villains）でコンテンツが多い場合に正しくスクロールできることを確認
- [ ] missions詳細ページのレイアウトが正しく表示されることを確認
- [ ] ホームページのレイアウトに問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)