### PR TITLE
fix: ページレイアウトとスクロール挙動の改善、Android PWA viewport問題の修正

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import { GlassScreenProvider, Toaster, ToastProvider } from '@superbetter/ui';
+import { ViewportHeight } from '@/components/viewport-height';
 import { pixelMPlus } from '@/fonts';
 import { css } from '@/styled-system/css';
 import { SortableProvider } from './_components/sortable/provider';
@@ -62,7 +63,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={pixelMPlus.className}>
-      <body className={css({ height: '[100dvh]' })}>
+      <body className={css({ height: '[var(--app-height, 100dvh)]' })}>
+        <ViewportHeight />
         <GlassScreenProvider>
           <ToastProvider>
             <SortableProvider>{children}</SortableProvider>

--- a/apps/web/src/components/viewport-height/index.tsx
+++ b/apps/web/src/components/viewport-height/index.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function ViewportHeight() {
+  useEffect(() => {
+    const setViewportHeight = () => {
+      const vh = window.innerHeight;
+      document.documentElement.style.setProperty('--app-height', `${vh}px`);
+    };
+
+    setViewportHeight();
+
+    window.addEventListener('resize', setViewportHeight);
+
+    window.addEventListener('orientationchange', () => {
+      setTimeout(setViewportHeight, 100);
+    });
+
+    return () => {
+      window.removeEventListener('resize', setViewportHeight);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- 各ページ（ホーム、クエスト、パワーアップ、ヴィラン、ミッション詳細）のレイアウトとスクロール挙動を改善
- Android PWA でリロード時に viewport 高さが正しく計算されない問題を JavaScript で解決

## Changes

### 1. ページレイアウトの改善
- 各ページのスクロールコンテナを修正
- flexbox レイアウトを適用し、ヘッダーとコンテンツの配置を最適化

### 2. ViewportHeight コンポーネントの追加
- `window.innerHeight` を使用して `--app-height` CSS 変数を動的に設定
- `resize` / `orientationchange` イベントに対応
- CSS の `100dvh` が正しく動作しない Android PWA 環境での代替策

## Test plan

- [ ] Android PWA でアプリをリロードし、画面が正しく表示されることを確認
- [ ] 各ページでスクロールが正しく動作することを確認
- [ ] 画面回転時にレイアウトが正しく更新されることを確認

---
Generated with [Claude Code](https://claude.com/claude-code)